### PR TITLE
docs: update package version and CHANGELOG.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-02-03
+
+### Changed
+
+- **Lightweight dependency**: Replaced `pydantic-ai` with `pydantic-ai-slim` to reduce install footprint — pulls in only the core modules needed by the toolset
+- **Removed CLI**: Dropped the CLI entry point to keep the package focused as a library-only toolset
+
 ## [0.1.5] - 2025-01-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-todo"
-version = "0.1.5"
+version = "0.1.6"
 description = "Todo/task planning toolset for pydantic-ai agents"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## [0.1.6] - 2026-02-03

### Changed

- **Lightweight dependency**: Replaced `pydantic-ai` with `pydantic-ai-slim` to reduce install footprint — pulls in only the core modules needed by the toolset
- **Removed CLI**: Dropped the CLI entry point to keep the package focused as a library-only toolset
