### PR TITLE
Feat/bump package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-03-31
+
+### Changed
+
+- Bump minimum `pydantic-ai-slim` to `>=1.74.0` for compatibility with async `get_instructions` on toolsets
+
 ## [0.2.0] - 2026-03-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = ["pydantic-ai-slim>=1.71.0", "pydantic>=2.0", "asyncpg>=0.29.0"]
+dependencies = ["pydantic-ai-slim>=1.74.0", "pydantic>=2.0", "asyncpg>=0.29.0"]
 
 [project.urls]
 Homepage = "https://github.com/vstorm-co/pydantic-ai-todo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-todo"
-version = "0.2.0"
+version = "0.2.1"
 description = "Todo/task planning toolset for pydantic-ai agents"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## [0.2.1] - 2026-03-31

### Changed

- Bump minimum `pydantic-ai-slim` to `>=1.74.0` for compatibility with async `get_instructions` on toolsets
