### PR TITLE
fix: AsyncRedisStorage atomicity + cluster safety + idempotent init (bump 0.2.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,9 +209,8 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
+# Ignore git attribute file
+.gitattributes
 
-# Ingore git attribute file 
-.gitattributes  
-
-# Ignore the devcontainer files 
+# Ignore the devcontainer files
 .devcontainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-05-24
+
+### Added
+
+- **`AsyncRedisStorage` — third storage backend, Redis-based** ([#18](https://github.com/vstorm-co/pydantic-ai-todo/pull/18) by [@shamalgithub](https://github.com/shamalgithub)). Stores each session's todos in a Redis Hash (one field per todo, JSON-serialized) with a companion List for insertion order. Supports either URL-based construction (`AsyncRedisStorage(url="redis://...", session_id=...)`) or injection of an existing `redis.asyncio.Redis` client (`AsyncRedisStorage(client=..., session_id=...)`). Session-scoped keys give multi-tenancy out of the box, the event emitter integration mirrors the other backends (CREATED, UPDATED, STATUS_CHANGED, COMPLETED, DELETED), and `create_storage("redis", ...)` plus a new overload land the factory shape. Adds `redis>=7.4.0` as a dependency and exports `AsyncRedisStorage` from the package root.
+
+### Fixed
+
+- **`AsyncRedisStorage.remove_todo` is now atomic.** The previous two-round-trip implementation (`hdel` then `lrem`) could leave the order list pointing at a deleted hash entry if the connection dropped between the two; both ops now go through a single pipeline so they cannot diverge.
+- **`AsyncRedisStorage` is Redis Cluster-safe.** `_hash_key` and `_order_key` now share a `{session_id}` hash-tag (`todos:{user-123}` / `todos:{user-123}:order`) so both keys route to the same Cluster slot. Without it the multi-key pipelines in `set_todos` / `add_todo` / `remove_todo` would fail with `CROSSSLOT` under clustered deployments. No-op on single-node Redis.
+- **`AsyncRedisStorage.initialize()` is now idempotent.** A second call is a no-op instead of issuing another `PING`.
+- **`.gitignore` cleanup** — fixed an "Ingore" typo, trimmed trailing whitespace, and added the missing final newline introduced in #18.
+
 ## [0.2.1] - 2026-03-31
 
 ### Changed

--- a/pydantic_ai_todo/storage.py
+++ b/pydantic_ai_todo/storage.py
@@ -663,19 +663,36 @@ class AsyncRedisStorage:
 
     @property
     def _hash_key(self) -> str:
-        """Redis Hash key storing todo data keyed by todo ID."""
-        return f"{self._key_prefix}:{self._session_id}"
+        """Redis Hash key storing todo data keyed by todo ID.
+
+        The session id is wrapped in ``{...}`` so Redis Cluster hashes
+        it as a single hash-tag, keeping :attr:`_hash_key` and
+        :attr:`_order_key` co-located on the same slot. Without that
+        guarantee the multi-key pipelines in :meth:`set_todos`,
+        :meth:`add_todo` and :meth:`remove_todo` would fail with
+        ``CROSSSLOT`` under clustered deployments. On single-node Redis
+        the hash-tag is a no-op.
+        """
+        return f"{self._key_prefix}:{{{self._session_id}}}"
 
     @property
     def _order_key(self) -> str:
-        """Redis List key maintaining insertion order of todo IDs."""
-        return f"{self._key_prefix}:{self._session_id}:order"
+        """Redis List key maintaining insertion order of todo IDs.
+
+        Shares the ``{session_id}`` hash-tag with :attr:`_hash_key` so
+        both keys route to the same Redis Cluster slot.
+        """
+        return f"{self._key_prefix}:{{{self._session_id}}}:order"
 
     async def initialize(self) -> None:
         """Initialize storage: create client if needed and verify connectivity.
 
-        Must be called before using the storage.
+        Idempotent — calling more than once is a no-op after the first
+        successful initialization.
         """
+        if self._initialized:
+            return
+
         if self._client is None and self._url:
             self._client = redis_async.from_url(self._url)
 
@@ -815,16 +832,25 @@ class AsyncRedisStorage:
         return current
 
     async def remove_todo(self, id: str) -> bool:
-        """Remove a todo by ID for current session."""
+        """Remove a todo by ID for current session.
+
+        Hash and order-list deletion happen atomically inside a single
+        pipeline so a connection drop between the two cannot leave the
+        order list pointing at a deleted hash entry.
+        """
         client = self._ensure_initialized()
 
         todo = await self.get_todo(id) if self._event_emitter else None
 
-        removed: int = await client.hdel(self._hash_key, id)  # type: ignore[misc]
-        if removed:
-            await client.lrem(self._order_key, 1, id)  # type: ignore[misc]
+        # Pipeline both ops so we never end up with an orphaned id in the
+        # order list. ``lrem`` on a missing id is a no-op, so it is safe
+        # to send unconditionally.
+        pipe = client.pipeline()
+        pipe.hdel(self._hash_key, id)
+        pipe.lrem(self._order_key, 1, id)
+        results: list[int] = await pipe.execute()
 
-        deleted = removed > 0
+        deleted = int(results[0]) > 0
 
         if deleted and todo and self._event_emitter:
             from pydantic_ai_todo.events import TodoEvent, TodoEventType

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-todo"
-version = "0.2.1"
+version = "0.2.2"
 description = "Todo/task planning toolset for pydantic-ai agents"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_redis_storage.py
+++ b/tests/test_redis_storage.py
@@ -71,22 +71,35 @@ class TestAsyncRedisStorageInit:
         assert storage._event_emitter is emitter
 
     def test_hash_key_property(self) -> None:
-        """Test that _hash_key returns correct Redis key."""
+        """_hash_key wraps the session id in a Redis Cluster hash-tag."""
         storage = AsyncRedisStorage(
             url="redis://localhost:6379",
             session_id="user-123",
             key_prefix="mytodos",
         )
-        assert storage._hash_key == "mytodos:user-123"
+        assert storage._hash_key == "mytodos:{user-123}"
 
     def test_order_key_property(self) -> None:
-        """Test that _order_key returns correct Redis key."""
+        """_order_key shares the same hash-tag as _hash_key."""
         storage = AsyncRedisStorage(
             url="redis://localhost:6379",
             session_id="user-123",
             key_prefix="mytodos",
         )
-        assert storage._order_key == "mytodos:user-123:order"
+        assert storage._order_key == "mytodos:{user-123}:order"
+
+    def test_keys_share_hash_tag_for_cluster_safety(self) -> None:
+        """_hash_key and _order_key MUST land in the same Cluster slot.
+
+        Redis Cluster routes by the substring between ``{`` and ``}``; if
+        the two keys had different hash tags, the multi-key pipelines in
+        set_todos/add_todo/remove_todo would fail with CROSSSLOT under a
+        clustered deployment.
+        """
+        storage = AsyncRedisStorage(url="redis://localhost:6379", session_id="abc-xyz")
+        hash_tag_h = storage._hash_key.split("{", 1)[1].split("}", 1)[0]
+        hash_tag_o = storage._order_key.split("{", 1)[1].split("}", 1)[0]
+        assert hash_tag_h == hash_tag_o == "abc-xyz"
 
 
 class TestAsyncRedisStorageNotInitialized:
@@ -123,6 +136,8 @@ class TestAsyncRedisStorageMocked:
         pipe.rpush = MagicMock(return_value=pipe)
         pipe.delete = MagicMock(return_value=pipe)
         pipe.hget = MagicMock(return_value=pipe)
+        pipe.hdel = MagicMock(return_value=pipe)
+        pipe.lrem = MagicMock(return_value=pipe)
         pipe.execute = AsyncMock(return_value=[])
         client.pipeline = MagicMock(return_value=pipe)
 
@@ -146,6 +161,20 @@ class TestAsyncRedisStorageMocked:
         )
         await storage.initialize()
 
+        mock_client.ping.assert_called_once()
+        assert storage._initialized
+
+    async def test_initialize_is_idempotent(self, mock_client: MagicMock) -> None:
+        """Calling initialize() more than once is a no-op after the first."""
+        storage = AsyncRedisStorage(
+            client=mock_client,
+            session_id="test-session",
+        )
+        await storage.initialize()
+        await storage.initialize()
+        await storage.initialize()
+
+        # Only the first call should reach the server.
         mock_client.ping.assert_called_once()
         assert storage._initialized
 
@@ -345,28 +374,34 @@ class TestAsyncRedisStorageMocked:
         assert result is None
 
     async def test_remove_todo(self, storage: AsyncRedisStorage, mock_client: MagicMock) -> None:
-        """Test removing a todo."""
-        mock_client.hdel = AsyncMock(return_value=1)
-        mock_client.lrem = AsyncMock(return_value=1)
+        """remove_todo pipelines hdel + lrem so they cannot diverge."""
+        pipe = mock_client.pipeline.return_value
+        pipe.execute = AsyncMock(return_value=[1, 1])  # hdel removed 1, lrem removed 1
 
         result = await storage.remove_todo("abc12345")
 
         assert result is True
-        mock_client.hdel.assert_called_once()
-        mock_client.lrem.assert_called_once()
+        # Both ops go through the same pipeline — never a separate round-trip.
+        pipe.hdel.assert_called_once()
+        pipe.lrem.assert_called_once()
+        pipe.execute.assert_awaited_once()
+        # And nothing is sent directly on the client.
+        mock_client.hdel.assert_not_called()
+        mock_client.lrem.assert_not_called()
 
     async def test_remove_todo_not_found(
         self, storage: AsyncRedisStorage, mock_client: MagicMock
     ) -> None:
-        """Test removing a non-existent todo."""
-        mock_client.hdel = AsyncMock(return_value=0)
+        """remove_todo returns False when the hash field did not exist."""
+        pipe = mock_client.pipeline.return_value
+        pipe.execute = AsyncMock(return_value=[0, 0])
 
         result = await storage.remove_todo("nonexistent")
 
         assert result is False
 
     async def test_remove_todo_emits_event(self, mock_client: MagicMock) -> None:
-        """Test that remove_todo emits DELETED event."""
+        """remove_todo emits DELETED event when the todo existed."""
         emitter = TodoEventEmitter()
         events: list[tuple[TodoEventType, Todo]] = []
 
@@ -383,8 +418,8 @@ class TestAsyncRedisStorageMocked:
 
         todo = Todo(id="abc12345", content="Test", status="pending", active_form="Testing")
         mock_client.hget = AsyncMock(return_value=todo.model_dump_json().encode())
-        mock_client.hdel = AsyncMock(return_value=1)
-        mock_client.lrem = AsyncMock(return_value=1)
+        pipe = mock_client.pipeline.return_value
+        pipe.execute = AsyncMock(return_value=[1, 1])
 
         await storage.remove_todo("abc12345")
 


### PR DESCRIPTION
Follow-up to #18 addressing four review findings before the 0.2.2 release. Ships in the same version as the Redis backend itself.

## Fixes

### 1. `remove_todo` is now atomic
Previously `hdel` and `lrem` were two separate round-trips. If the connection dropped between them, the order list kept a stale id pointing at a deleted hash entry — `get_todos`'s "skip-missing" defense would hide the symptom but the garbage never got cleaned up. Both ops now share a single pipeline (matching `add_todo`).

### 2. Redis Cluster safety via hash-tags
`_hash_key` and `_order_key` now wrap the session id in `{...}`:

```python
return f"{self._key_prefix}:{{{self._session_id}}}"        # todos:{user-123}
return f"{self._key_prefix}:{{{self._session_id}}}:order"  # todos:{user-123}:order
```

Redis Cluster routes by the substring between `{` and `}`. Without this both keys hash to different slots and every multi-key pipeline in the backend (`set_todos`, `add_todo`, `remove_todo`) would fail with `CROSSSLOT`. With the tag, both keys always co-locate, so the pipeline's MULTI/EXEC stays atomic under clustered deployments. No-op on single-node.

PR #18 hasn't been released yet, so there are no existing keys in users' Redis to migrate.

### 3. `initialize()` is idempotent
Adds an early-return on `self._initialized`. Calling twice no longer triggers a second `PING`.

### 4. `.gitignore` cleanup
`Ingore` → `Ignore` typo fix, trailing whitespace trimmed, missing EOL newline added.

## Tests

- New `test_keys_share_hash_tag_for_cluster_safety` — extracts the tag from both keys and asserts they match. Regression for #2.
- New `test_initialize_is_idempotent` — three consecutive `initialize()` calls, exactly one `ping`. Regression for #3.
- `test_remove_todo` / `test_remove_todo_not_found` / `test_remove_todo_emits_event` rewritten to drive through `pipe` (instead of direct `client.hdel`/`client.lrem`), and to assert `client.hdel/lrem` are NOT called. Catches future regressions of #1.
- Existing key-string assertions updated to the hash-tagged format.

## Out of scope (follow-ups noted)

- `update_todo` TOCTOU race — matches the existing `AsyncPostgresStorage` pattern; deserves a proper cross-backend fix (WATCH/MULTI or Lua on Redis, `SELECT FOR UPDATE` on Postgres).
- `redis` / `asyncpg` as `[project.optional-dependencies]` extras.
- Lowering the `redis>=7.4.0` floor — the surface used here works on 4.2+.
- CI service container for real-Redis integration tests.

## Gate

- 273 passed + 6 integration-skipped, **100% coverage**.
- `ruff format --check`, `ruff check`, `pyright` all clean.

## Release

Bumps `version` from 0.2.1 to **0.2.2**. CHANGELOG documents the new Redis backend (credit @shamalgithub / #18) plus these fixes under one release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)