### PR TITLE
chore: release 0.2.3 — consolidated CI action bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -40,10 +40,10 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python
         run: uv python install 3.12
@@ -62,10 +62,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,12 +12,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,8 +11,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync --group dev
       - run: uv run python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-05-24
+
+### Infrastructure
+
+Pure CI / dependency-bot housekeeping — no source-code changes, no behaviour change since 0.2.2. Consolidates the open Renovate auto-PRs and the rate-limited items from the [Dependency Dashboard #24](https://github.com/vstorm-co/pydantic-ai-todo/issues/24) into a single release so downstream consumers see one bump instead of four.
+
+- **CI: bump `actions/checkout` to `v6`** across `ci.yml` (×3), `docs.yml`, `publish.yml` ([#23](https://github.com/vstorm-co/pydantic-ai-todo/pull/23), Renovate auto-PR — folded in here).
+- **CI: bump `docs.yml` Python to `3.14`** ([#22](https://github.com/vstorm-co/pydantic-ai-todo/pull/22), Renovate auto-PR — folded in here).
+- **CI: bump `astral-sh/setup-uv` to `v8.1.0`** across `ci.yml` (×3) and `publish.yml` — from Dashboard #24. Pinned to the specific patch because `astral-sh/setup-uv` does not maintain a rolling `v8` tag (only `v8.0.0` / `v8.1.0`; `v7` and earlier do have rolling majors).
+- **CI: bump `actions/setup-python` to `v6`** in `docs.yml` — from Dashboard #24; `v6` has a rolling tag so plain `@v6` is used.
+
+The `ci.yml` test matrix (`["3.10", "3.13"]` and `["3.10", "3.11", "3.12", "3.13"]`) is unchanged in this release.
+
 ## [0.2.2] - 2026-05-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-todo"
-version = "0.2.2"
+version = "0.2.3"
 description = "Todo/task planning toolset for pydantic-ai agents"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Folds **#22** + **#23** + the rate-limited items from Renovate's [Dependency Dashboard #24](https://github.com/vstorm-co/pydantic-ai-todo/issues/24) into **one** release so downstream consumers see a single bump instead of four.

## Bumps

| Action | From | To | Files | Source |
|---|---|---|---|---|
| `actions/checkout` | `v4` | `v6` | `ci.yml` (×3), `docs.yml`, `publish.yml` | #23 |
| Python in `docs.yml` | `3.12` | `3.14` | `docs.yml` | #22 |
| `astral-sh/setup-uv` | `v4` | `v8.1.0` | `ci.yml` (×3), `publish.yml` | #24 |
| `actions/setup-python` | `v5` | `v6` | `docs.yml` | #24 |

`setup-uv` is pinned to the specific patch — the repo does **not** maintain a rolling `v8` tag (only `v8.0.0` / `v8.1.0` exist; `v7` and earlier do have rolling majors). Same lesson learned in summarization-pydantic-ai#23 and pydantic-ai-backend#43.

The `ci.yml` test matrix (`["3.10", "3.13"]` + `["3.10", "3.11", "3.12", "3.13"]`) is unchanged.

## Why one PR instead of three

Each of #22 / #23 / and the two Dashboard items would land as its own PR, each forcing a release for downstream Renovate to pick up. Consolidating into one release means **one merge, one publish, one downstream bump** — much less churn in `pydantic-deep`'s changelog.

## Closing

Closes #22
Closes #23

## Gate

- `make test` — **273 passed + 6 integration-skipped**, 100% coverage
- `ruff format --check` + `ruff check` — clean
- `pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)