### PR TITLE
feat: make asyncpg an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`asyncpg` is now an optional dependency.** `pip install pydantic-ai-todo` no longer pulls in a Postgres driver — install `pip install 'pydantic-ai-todo[postgres]'` to use `AsyncPostgresStorage`. Users on psycopg3, custom backends, or the in-memory/Redis storage no longer pay the unused-dep cost. `AsyncPostgresStorage.initialize()` raises an `ImportError` with the install hint if the extra is missing. `redis` remains a required dependency; a follow-up may give it the same treatment. Resolves [#19](https://github.com/vstorm-co/pydantic-ai-todo/issues/19).
+
 ## [0.2.5]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ agent = Agent("openai:gpt-4.1", capabilities=[TodoCapability(async_storage=stora
 
 ### PostgreSQL
 
+> Requires the `postgres` extra: `pip install 'pydantic-ai-todo[postgres]'`
+
 ```python
 from pydantic_ai_todo import TodoCapability, create_storage
 

--- a/pydantic_ai_todo/storage.py
+++ b/pydantic_ai_todo/storage.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal, Protocol, overload, runtime_checkable
 
-import asyncpg
 import redis.asyncio as redis_async
 
 from pydantic_ai_todo.types import Todo
 
 if TYPE_CHECKING:
+    import asyncpg
+
     from pydantic_ai_todo.events import TodoEventEmitter
 
 
@@ -365,6 +366,13 @@ class AsyncPostgresStorage:
         Must be called before using the storage.
         """
         if self._pool is None and self._connection_string:
+            try:
+                import asyncpg
+            except ImportError as e:
+                raise ImportError(
+                    "AsyncPostgresStorage requires the 'postgres' extra. "
+                    "Install it with: pip install 'pydantic-ai-todo[postgres]'"
+                ) from e
             self._pool = await asyncpg.create_pool(self._connection_string)
 
         if self._pool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,11 @@ classifiers = [
 dependencies = [
     "pydantic-ai-slim>=1.74.0",
     "pydantic>=2.0",
-    "asyncpg>=0.29.0",
     "redis>=7.4.0",
 ]
+
+[project.optional-dependencies]
+postgres = ["asyncpg>=0.29.0"]
 
 [project.urls]
 Homepage = "https://github.com/vstorm-co/pydantic-ai-todo"
@@ -43,6 +45,7 @@ packages = ["pydantic_ai_todo"]
 
 [dependency-groups]
 dev = [
+    "asyncpg>=0.29.0",
     "build>=1.0.0",
     "coverage>=7.0.0",
     "pyright>=1.1.0",

--- a/tests/test_optional_deps.py
+++ b/tests/test_optional_deps.py
@@ -1,0 +1,103 @@
+"""Tests for optional dependency handling.
+
+Verifies that `asyncpg` is truly optional: the package imports cleanly
+without it, and `AsyncPostgresStorage.initialize()` raises a helpful
+`ImportError` pointing to the `postgres` extra.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+from pydantic_ai_todo import AsyncPostgresStorage
+
+
+@pytest.fixture
+def _blocking_import() -> Iterator[None]:
+    """Block `import asyncpg` for the duration of the test.
+
+    Monkeypatches `builtins.__import__` so any attempt to import the
+    top-level `asyncpg` module raises `ModuleNotFoundError`. Other imports
+    are unaffected. Cleanup restores the real importer.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocking_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "asyncpg":
+            raise ModuleNotFoundError("No module named 'asyncpg'")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    with patch.object(builtins, "__import__", blocking_import):
+        yield
+
+
+class TestAsyncpgOptional:
+    """Tests verifying asyncpg is an optional dependency."""
+
+    def test_package_imports_without_asyncpg(self) -> None:
+        """`pydantic_ai_todo` imports cleanly when asyncpg is unavailable.
+
+        Uses a subprocess to guarantee a fresh interpreter where asyncpg
+        is blocked via `sys.modules['asyncpg'] = None`. An in-process
+        reload would leak state across tests that already imported asyncpg.
+        """
+        code = (
+            "import sys\n"
+            "sys.modules['asyncpg'] = None\n"
+            "import pydantic_ai_todo\n"
+            "from pydantic_ai_todo import AsyncPostgresStorage\n"
+            "print('ok')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"Expected clean import without asyncpg, got:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert result.stdout.strip() == "ok"
+
+    async def test_initialize_raises_install_hint_without_asyncpg(self) -> None:
+        """`initialize()` raises `ImportError` with the postgres-extra hint."""
+        storage = AsyncPostgresStorage(
+            connection_string="postgresql://localhost/test",
+            session_id="test-session",
+        )
+
+        with (
+            patch.dict(sys.modules, {"asyncpg": None}),
+            pytest.raises(ImportError) as exc_info,
+        ):
+            await storage.initialize()
+
+        assert "postgres" in str(exc_info.value)
+        assert "pydantic-ai-todo[postgres]" in str(exc_info.value)
+
+    async def test_initialize_with_pool_skips_asyncpg_import(self, _blocking_import: None) -> None:
+        """A pre-supplied pool does not require asyncpg to be importable.
+
+        `initialize()` only imports asyncpg when it needs to create a pool
+        itself. If the caller passes `pool=...`, the import is never reached.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        mock_pool = MagicMock()
+        mock_conn = AsyncMock()
+        mock_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+        mock_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        storage = AsyncPostgresStorage(pool=mock_pool, session_id="test-session")
+        await storage.initialize()
+        assert storage._initialized

--- a/uv.lock
+++ b/uv.lock
@@ -429,14 +429,19 @@ name = "pydantic-ai-todo"
 version = "0.2.5"
 source = { editable = "." }
 dependencies = [
-    { name = "asyncpg" },
     { name = "pydantic" },
     { name = "pydantic-ai-slim" },
     { name = "redis" },
 ]
 
+[package.optional-dependencies]
+postgres = [
+    { name = "asyncpg" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "asyncpg" },
     { name = "build" },
     { name = "coverage" },
     { name = "pyright" },
@@ -448,14 +453,16 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "asyncpg", marker = "extra == 'postgres'", specifier = ">=0.29.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-ai-slim", specifier = ">=1.74.0" },
     { name = "redis", specifier = ">=7.4.0" },
 ]
+provides-extras = ["postgres"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "build", specifier = ">=1.0.0" },
     { name = "coverage", specifier = ">=7.0.0" },
     { name = "pyright", specifier = ">=1.1.0" },


### PR DESCRIPTION
## Summary

- `pip install pydantic-ai-todo` no longer pulls in a Postgres driver. Users who need `AsyncPostgresStorage` install `pip install 'pydantic-ai-todo[postgres]'` instead.
- The top-level `import asyncpg` in `storage.py` is replaced with a `TYPE_CHECKING`-guarded import (type annotations still resolve because of PEP 563 / `from __future__ import annotations`) plus a runtime import inside `AsyncPostgresStorage.initialize()` that raises a clear `ImportError` pointing at the extra if it's missing.
- `redis` is intentionally left as a required dependency — same pattern could be applied in a follow-up if there's appetite.

Closes #19.

## Why

`asyncpg` was being installed for every user even though only `AsyncPostgresStorage` uses it. Users on psycopg3, custom backends (via `TodoStorageProtocol`), or the in-memory/Redis storage pay the unused-dep cost for nothing. The storage protocol already lets users plug in custom backends, so this is packaging hygiene.

## User-facing migration

If you currently use `AsyncPostgresStorage`, change your install command:

```diff
- pip install pydantic-ai-todo
+ pip install 'pydantic-ai-todo[postgres]'
```

If you forget, `AsyncPostgresStorage(...).initialize()` fails fast with:

```
ImportError: AsyncPostgresStorage requires the 'postgres' extra.
Install it with: pip install 'pydantic-ai-todo[postgres]'
```

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run pyright` — 0 errors
- [x] `uv run coverage run -m pytest && uv run coverage report` — 292 passed, 6 skipped, **100% coverage** maintained
- [x] `tests/test_optional_deps.py::TestAsyncpgOptional` (3 new tests):
  - `test_package_imports_without_asyncpg` — subprocess imports the package with `sys.modules['asyncpg'] = None`
  - `test_initialize_raises_install_hint_without_asyncpg` — confirms the `ImportError` + install hint
  - `test_initialize_with_pool_skips_asyncpg_import` — confirms a pre-supplied pool never touches the asyncpg import
- [x] End-to-end smoke check: `python -c "sys.modules['asyncpg']=None; import pydantic_ai_todo"` succeeds and `initialize()` raises the expected error

## Notes for review

- This is **draft** pending maintainer sign-off on the user-facing migration (existing postgres users must add `[postgres]`).
- `uv.lock` is updated: `asyncpg` moves from core to the dev group + the `postgres` extra.
- `pydantic-deep` re-exports this package — it should keep working because the class definition with PEP 563 annotations doesn't trigger the import, but worth a downstream check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)