### PR TITLE
chore(release): 0.2.6 — optional asyncpg dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.6] - 2026-06-17
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-todo"
-version = "0.2.5"
+version = "0.2.6"
 description = "Todo/task planning toolset for pydantic-ai agents"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Release **0.2.6**.

- Bumps version `0.2.5` → `0.2.6` in `pyproject.toml`.
- Promotes the `[Unreleased]` CHANGELOG section (optional `asyncpg` dependency, #36 / #19) to `## [0.2.6] - 2026-06-17`.

No code changes — packaging/release bookkeeping only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)