### PR TITLE
docs: point to pydantic-ai-harness planning as the upstream home

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,49 @@
 
 ---
 
+> ### ⬆️ Upstreamed to `pydantic-ai-harness`
+>
+> Working together with the Pydantic team, we folded this library into the official
+> **[pydantic-ai-harness](https://github.com/pydantic/pydantic-ai-harness)** — it now lives in
+> [`pydantic_ai_harness/planning`](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/planning)
+> ([PR #404](https://github.com/pydantic/pydantic-ai-harness/pull/404), merged), which supersedes this package.
+>
+> **For new projects, use the harness** — it is maintained by Pydantic alongside Pydantic AI itself. This
+> repository stays on PyPI and keeps working for everyone already depending on it.
+>
+> ```python
+> from pydantic_ai import Agent
+> from pydantic_ai_harness.planning import Planning
+>
+> agent = Agent("openai:gpt-5.4", capabilities=[Planning(enable_subtasks=True)])
+> ```
+>
+> **Tools were renamed**
+>
+> | Here | In the harness |
+> |---|---|
+> | `write_todos` | `write_plan` |
+> | `read_todos` | `read_plan` |
+> | `add_todo` | `add_task` |
+> | `update_todo_status` / `update_todo_statuses` | `update_task_status` / `update_task_statuses` |
+> | `remove_todo` | `remove_task` |
+> | `add_subtask`, `set_dependency`, `get_available_tasks` | unchanged |
+>
+> **API mapping**
+>
+> | Here | In `pydantic_ai_harness.planning` |
+> |---|---|
+> | `TodoCapability` | `Planning` |
+> | `TodoStorage`, `AsyncMemoryStorage` | `InMemoryPlanStore` |
+> | `AsyncPostgresStorage` / `create_storage("postgres", connection_string=…)` | `PostgresPlanStore` — takes a **caller-owned** asyncpg-compatible pool, so the harness pulls in no database driver |
+> | `create_todo_toolset()` | `PlanningToolset` |
+> | `get_todo_system_prompt()` | not needed — `Planning` surfaces the plan as an ephemeral tail reminder behind a `CachePoint`, so the cached prefix stays byte-identical across turns |
+> | `Todo`, `TodoItem` | `PlanItem` |
+> | `TodoEvent`, `TodoEventType`, `TodoEventEmitter` | `PlanEvent`, `PlanEventType`, `PlanEventEmitter` |
+>
+> The harness also adds `SqlitePlanStore` and `RedisPlanStore`, and a `blocked` task status, none of which
+> exist here.
+
 **Todo Toolset for Pydantic AI** adds task planning capabilities to any [Pydantic AI](https://ai.pydantic.dev/) agent. Your agent can create, track, and complete tasks with full support for subtasks, dependencies, and persistent storage.
 
 > **Full framework?** Check out [Pydantic Deep Agents](https://github.com/vstorm-co/pydantic-deepagents) — complete agent framework with planning, filesystem, subagents, and skills.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,24 @@
 
 ---
 
+!!! info "Upstreamed to `pydantic-ai-harness`"
+    Working together with the Pydantic team, we folded this library into the official
+    [pydantic-ai-harness](https://github.com/pydantic/pydantic-ai-harness) — it now lives in
+    [`pydantic_ai_harness/planning`](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/planning)
+    ([PR #404](https://github.com/pydantic/pydantic-ai-harness/pull/404), merged), which supersedes this
+    package.
+
+    **For new projects, use the harness.** This library stays on PyPI and keeps working for everyone
+    already depending on it. The [README](https://github.com/vstorm-co/pydantic-ai-todo#readme) has the
+    full mapping — note the tools were renamed (`write_todos` → `write_plan`, `add_todo` → `add_task`, …).
+
+    ```python
+    from pydantic_ai import Agent
+    from pydantic_ai_harness.planning import Planning
+
+    agent = Agent("openai:gpt-5.4", capabilities=[Planning(enable_subtasks=True)])
+    ```
+
 **Todo Toolset for Pydantic AI** adds task planning capabilities to any [Pydantic AI](https://ai.pydantic.dev/) agent. Your agent can create, track, and complete tasks with full support for subtasks, dependencies, and persistent storage.
 
 Think of it as giving your AI agent a todo list — so it can break down complex work, track progress, and remember what needs to be done.


### PR DESCRIPTION
## Summary

Working together with the Pydantic team, this library was folded into the official
[pydantic-ai-harness](https://github.com/pydantic/pydantic-ai-harness), where it now lives as
[`pydantic_ai_harness/planning`](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/planning)
([PR #404](https://github.com/pydantic/pydantic-ai-harness/pull/404), merged). That PR states in so
many words that it supersedes this package — and nothing here said so, so anyone landing on the
README had no way to know.

This adds a callout at the top of the README (and the docs landing page) with:

- **The tool renames**, which is the part that actually breaks a migration: `write_todos` →
  `write_plan`, `read_todos` → `read_plan`, `add_todo` → `add_task`, `update_todo_status(es)` →
  `update_task_status(es)`, `remove_todo` → `remove_task`. The subtask tools keep their names.
- **The API mapping**: `TodoCapability` → `Planning`, the storage classes → `InMemoryPlanStore` /
  `PostgresPlanStore` (caller-owned pool, so the harness pulls in no driver), `create_todo_toolset()`
  → `PlanningToolset`, the event types → `PlanEvent` / `PlanEventType` / `PlanEventEmitter`.
- **What is gained**: `get_todo_system_prompt()` has no counterpart because `Planning` surfaces the
  plan as an ephemeral tail reminder behind a `CachePoint`; plus `SqlitePlanStore`, `RedisPlanStore`,
  and a `blocked` status, none of which exist here.

The recommendation is *use the harness for new projects*; this library stays on PyPI and keeps
working for existing users. No code, dependency, or packaging change.

Same treatment as vstorm-co/summarization-pydantic-ai#42 and vstorm-co/pydantic-ai-shields#40.